### PR TITLE
Adding set_escape_key_method and set_unescape_key_method 

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -93,9 +93,15 @@ The `key` argument provided in the following methods will be automatically escap
 
 new
 ---
-`syntax: memc, err = memcached:new()`
+`syntax: memc, err = memcached:new(opts)`
 
 Creates a memcached object. In case of failures, returns `nil` and a string describing the error.
+
+It accepts an optional `opts` table argument. The following options are supported:
+
+* `key_transform`
+    a table containing the method to serialize, and un-serialize the key to put in memcache
+    Note : memached:new{ key_transform = { ngx.escape_uri, ngx.unescape_uri }} is the default behavior.
 
 connect
 -------
@@ -134,26 +140,6 @@ set_timeout
 `syntax: memc:set_timeout(time)`
 
 Sets the timeout (in ms) protection for subsequent operations, including the `connect` method.
-
-set_escape_key_method
----------------------
-`syntax: memc:set_escape_key_method(method)`
-
-Specify a function to escape the key beforing inserting it in memc, for example
-
-    memc:set_escape_key_method(ngx.encode_base64)
-
-Note: the default is ngx.escape_uri
-
-set_unescape_key_method
------------------------
-`syntax: memc:set_unescape_key_method(method)`
-
-Specify a function to unescape the key fetched from memc, for example
-
-    memc:set_unescape_key_method(ngx.decode_base64)
-
-Note: the default is ngx.unescape_uri
 
 set_keepalive
 ------------

--- a/t/sanity.t
+++ b/t/sanity.t
@@ -2042,15 +2042,12 @@ failed to cas: EXISTS$
             end
 
             local memcached = require "resty.memcached"
-            local memc = memcached:new()
+            local memc = memcached:new{ key_transform = { identity, identity }}
             local key = "dog&cat"
-
-            memc:set_escape_key_method(identity)
-            memc:set_unescape_key_method(identity)
 
             memc:set_timeout(1000) -- 1 sec
 
-                local ok, err = memc:connect("127.0.0.1", $TEST_NGINX_MEMCACHED_PORT)
+            local ok, err = memc:connect("127.0.0.1", $TEST_NGINX_MEMCACHED_PORT)
             if not ok then
                 ngx.say("failed to connect: ", err)
                 return
@@ -2106,11 +2103,9 @@ dog&cat: 32 (flags: 0)
             end
 
             local memcached = require "resty.memcached"
-            local memc = memcached:new()
+            local memc = memcached:new{key_transform = {ngx.escape_uri, identity}}
 
             local key = "dog&cat"
-
-            memc:set_unescape_key_method(identity)
 
             memc:set_timeout(1000) -- 1 sec
 


### PR DESCRIPTION
This allows to fetch raw, base64, etc keys set by another external system

The default behavior stays to escape / unescape with ngx.escape_uri and ngx.unescape_uri, and should not affect existing code.
