### PR TITLE
gets: return socket send errors at the correct index

### DIFF
--- a/lib/resty/memcached.lua
+++ b/lib/resty/memcached.lua
@@ -290,7 +290,7 @@ function _M.gets(self, key)
 
     local bytes, err = sock:send("gets " .. self.escape_key(key) .. "\r\n")
     if not bytes then
-        return nil, nil, err
+        return nil, nil, nil, err
     end
 
     local line, err = sock:receive()


### PR DESCRIPTION
Other paths that return an error in the function use the 4th return value position for the error.