### PR TITLE
use preferred settimeouts instead of settimout

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -15,6 +15,7 @@ Table of Contents
     * [connect](#connect)
     * [set](#set)
     * [set_timeout](#set_timeout)
+    * [set_timeouts](#set_timeouts)
     * [set_keepalive](#set_keepalive)
     * [get_reused_times](#get_reused_times)
     * [close](#close)
@@ -201,13 +202,21 @@ The `flags` parameter is optional and defaults to `0`.
 
 set_timeout
 ----------
-`syntax: ok, err = memc:set_timeout(time)`
+`syntax: ok, err = memc:set_timeout(timeout)`
 
 Sets the timeout (in ms) protection for subsequent operations, including the `connect` method.
 
 Returns 1 when successful and nil plus a string describing the error otherwise.
 
 [Back to TOC](#table-of-contents)
+
+set_timeouts
+----------
+`syntax: ok, err = memc:set_timeouts(connect_timeout, send_timeout, read_timeout)`
+
+Sets the timeouts (in ms) for connect, send and read operations respectively.
+
+Returns 1 when successful and nil plus a string describing the error otherwise.
 
 set_keepalive
 ------------

--- a/lib/resty/memcached.lua
+++ b/lib/resty/memcached.lua
@@ -48,7 +48,7 @@ function _M.new(self, opts)
 end
 
 
-function _M.set_timeouts(self, connect, send, read)
+local function set_timeouts(self, connect, send, read)
     local sock = self.sock
     if not sock then
         return nil, "not initialized"
@@ -57,10 +57,10 @@ function _M.set_timeouts(self, connect, send, read)
     sock:settimeouts(connect, send, read)
     return 1
 end
-local set_timeouts = _M.set_timeouts
+_M.set_timeouts = set_timeouts
 
 function _M.set_timeout(self, timeout)
-    return set_timeouts(timeout, timeout, timeout)
+    return set_timeouts(self, timeout, timeout, timeout)
 end
 
 

--- a/lib/resty/memcached.lua
+++ b/lib/resty/memcached.lua
@@ -48,14 +48,19 @@ function _M.new(self, opts)
 end
 
 
-function _M.set_timeout(self, timeout)
+function _M.set_timeouts(self, connect, send, read)
     local sock = self.sock
     if not sock then
         return nil, "not initialized"
     end
 
-    sock:settimeout(timeout)
+    sock:settimeouts(connect, send, read)
     return 1
+end
+local set_timeouts = _M.set_timeouts
+
+function _M.set_timeout(self, timeout)
+    return set_timeouts(timeout, timeout, timeout)
 end
 
 

--- a/t/sanity.t
+++ b/t/sanity.t
@@ -86,7 +86,8 @@ dog: 32 (flags: 0)
             local memcached = require "resty.memcached"
             local memc = memcached:new()
 
-            memc:set_timeout(1000) -- 1 sec
+            -- 1 sec for all connect, read and send timeouts
+            memc:set_timeouts(1000, 1000, 1000)
 
             local ok, err = memc:connect("127.0.0.1", $TEST_NGINX_MEMCACHED_PORT)
             if not ok then

--- a/t/sanity.t
+++ b/t/sanity.t
@@ -86,8 +86,7 @@ dog: 32 (flags: 0)
             local memcached = require "resty.memcached"
             local memc = memcached:new()
 
-            -- 1 sec for all connect, read and send timeouts
-            memc:set_timeouts(1000, 1000, 1000)
+            memc:set_timeout(1000) -- 1 sec
 
             local ok, err = memc:connect("127.0.0.1", $TEST_NGINX_MEMCACHED_PORT)
             if not ok then
@@ -2191,6 +2190,62 @@ blah not found
 cat: hello
 world
  0 \d+$
+--- no_error_log
+[error]
+
+
+
+=== TEST 39: basic with set_timeouts
+--- http_config eval: $::HttpConfig
+--- config
+    location /t {
+        content_by_lua_block {
+            local memcached = require "resty.memcached"
+            local memc = memcached:new()
+
+            assert(memc:set_timeouts(1000, 1000, 1000))
+
+            local ok, err = memc:connect("127.0.0.1", $TEST_NGINX_MEMCACHED_PORT)
+            if not ok then
+                ngx.say("failed to connect: ", err)
+                return
+            end
+
+            local ok, err = memc:flush_all()
+            if not ok then
+                ngx.say("failed to flush all: ", err)
+                return
+            end
+
+            local ok, err = memc:set("dog", 32)
+            if not ok then
+                ngx.say("failed to set dog: ", err)
+                return
+            end
+
+            for i = 1, 2 do
+                local res, flags, err = memc:get("dog")
+                if err then
+                    ngx.say("failed to get dog: ", err)
+                    return
+                end
+
+                if not res then
+                    ngx.say("dog not found")
+                    return
+                end
+
+                ngx.say("dog: ", res, " (flags: ", flags, ")")
+            end
+
+            memc:close()
+        }
+    }
+--- request
+GET /t
+--- response_body
+dog: 32 (flags: 0)
+dog: 32 (flags: 0)
 --- no_error_log
 [error]
 


### PR DESCRIPTION
Currently the library exposes only `set_timeout`, which invokes `settimeout`. According to https://github.com/openresty/lua-nginx-module#tcpsocksettimeout `settimeout` configures timeout only for connect and receive operations. It says:

> Set the timeout value in milliseconds for subsequent socket operations (connect, receive, and iterators returned from receiveuntil).

It's actually unclear to me whether the timeout is also applied to `send` operations.

Also from https://github.com/openresty/lua-nginx-module#tcpsocksettimeouts:

> It is recommended to use settimeouts instead of settimeout.

Thus in this PR I'm introducing `set_timeouts` interface to configure connect, read and send timeouts explicitly. I'm also changing `set_timeout` to use `set_timeouts` internally instead of `settimeout`, due the above mentioned unclearness i'm not sure if this change is no-op or not for existing users.

If you prefer I can also just leave `set_timeout` as is and only introduce new `set_timeouts` function.

Note that this PR also makes `lua-resty-memcached` more consistent with `lua-resty-redis`.